### PR TITLE
SQLite: Allow dollar signs in placeholder names

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1123,15 +1123,18 @@ pub enum ColumnOption {
     /// `DEFAULT <restricted-expr>`
     Default(Expr),
 
-    /// ClickHouse supports `MATERIALIZE`, `EPHEMERAL` and `ALIAS` expr to generate default values.
-    /// Syntax: `b INT MATERIALIZE (a + 1)`
-    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
-
     /// `MATERIALIZE <expr>`
+    /// Syntax: `b INT MATERIALIZE (a + 1)`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Materialized(Expr),
     /// `EPHEMERAL [<expr>]`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Ephemeral(Option<Expr>),
     /// `ALIAS <expr>`
+    ///
+    /// [ClickHouse](https://clickhouse.com/docs/en/sql-reference/statements/create/table#default_values)
     Alias(Expr),
 
     /// `{ PRIMARY KEY | UNIQUE } [<constraint_characteristics>]`
@@ -1330,7 +1333,7 @@ pub enum GeneratedExpressionMode {
 #[must_use]
 fn display_constraint_name(name: &'_ Option<Ident>) -> impl fmt::Display + '_ {
     struct ConstraintName<'a>(&'a Option<Ident>);
-    impl<'a> fmt::Display for ConstraintName<'a> {
+    impl fmt::Display for ConstraintName<'_> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(name) = self.0 {
                 write!(f, "CONSTRAINT {name} ")?;
@@ -1351,7 +1354,7 @@ fn display_option<'a, T: fmt::Display>(
     option: &'a Option<T>,
 ) -> impl fmt::Display + 'a {
     struct OptionDisplay<'a, T>(&'a str, &'a str, &'a Option<T>);
-    impl<'a, T: fmt::Display> fmt::Display for OptionDisplay<'a, T> {
+    impl<T: fmt::Display> fmt::Display for OptionDisplay<'_, T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             if let Some(inner) = self.2 {
                 let (prefix, postfix) = (self.0, self.1);

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -99,7 +99,7 @@ where
     sep: &'static str,
 }
 
-impl<'a, T> fmt::Display for DisplaySeparated<'a, T>
+impl<T> fmt::Display for DisplaySeparated<'_, T>
 where
     T: fmt::Display,
 {

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1597,7 +1597,7 @@ impl fmt::Display for Join {
         }
         fn suffix(constraint: &'_ JoinConstraint) -> impl fmt::Display + '_ {
             struct Suffix<'a>(&'a JoinConstraint);
-            impl<'a> fmt::Display for Suffix<'a> {
+            impl fmt::Display for Suffix<'_> {
                 fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                     match self.0 {
                         JoinConstraint::On(expr) => write!(f, " ON {expr}"),

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -261,7 +261,7 @@ pub struct EscapeQuotedString<'a> {
     quote: char,
 }
 
-impl<'a> fmt::Display for EscapeQuotedString<'a> {
+impl fmt::Display for EscapeQuotedString<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // EscapeQuotedString doesn't know which mode of escape was
         // chosen by the user. So this code must to correctly display
@@ -325,7 +325,7 @@ pub fn escape_double_quote_string(s: &str) -> EscapeQuotedString<'_> {
 
 pub struct EscapeEscapedStringLiteral<'a>(&'a str);
 
-impl<'a> fmt::Display for EscapeEscapedStringLiteral<'a> {
+impl fmt::Display for EscapeEscapedStringLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.0.chars() {
             match c {
@@ -359,7 +359,7 @@ pub fn escape_escaped_string(s: &str) -> EscapeEscapedStringLiteral<'_> {
 
 pub struct EscapeUnicodeStringLiteral<'a>(&'a str);
 
-impl<'a> fmt::Display for EscapeUnicodeStringLiteral<'a> {
+impl fmt::Display for EscapeUnicodeStringLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for c in self.0.chars() {
             match c {

--- a/src/dialect/mod.rs
+++ b/src/dialect/mod.rs
@@ -527,6 +527,12 @@ pub trait Dialect: Debug + Any {
         false
     }
 
+    /// Returns true if this dialect allows dollar placeholders
+    /// e.g. `SELECT $var` (SQLite)
+    fn supports_dollar_placeholder(&self) -> bool {
+        false
+    }
+
     /// Does the dialect support with clause in create index statement?
     /// e.g. `CREATE INDEX idx ON t WITH (key = value, key2)`
     fn supports_create_index_with_clause(&self) -> bool {

--- a/src/dialect/sqlite.rs
+++ b/src/dialect/sqlite.rs
@@ -81,4 +81,8 @@ impl Dialect for SQLiteDialect {
     fn supports_asc_desc_in_column_definition(&self) -> bool {
         true
     }
+
+    fn supports_dollar_placeholder(&self) -> bool {
+        true
+    }
 }

--- a/src/parser/alter.rs
+++ b/src/parser/alter.rs
@@ -26,7 +26,7 @@ use crate::{
     tokenizer::Token,
 };
 
-impl<'a> Parser<'a> {
+impl Parser<'_> {
     pub fn parse_alter_role(&mut self) -> Result<Statement, ParserError> {
         if dialect_of!(self is PostgreSqlDialect) {
             return self.parse_pg_alter_role();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10458,13 +10458,12 @@ impl<'a> Parser<'a> {
         Ok(ExprWithAlias { expr, alias })
     }
     /// Parses an expression with an optional alias
-
+    ///
     /// Examples:
-
+    ///
     /// ```sql
     /// SUM(price) AS total_price
     /// ```
-
     /// ```sql
     /// SUM(price)
     /// ```
@@ -10480,7 +10479,6 @@ impl<'a> Parser<'a> {
     /// assert_eq!(Some("b".to_string()), expr_with_alias.alias.map(|x|x.value));
     /// # Ok(())
     /// # }
-
     pub fn parse_expr_with_alias(&mut self) -> Result<ExprWithAlias, ParserError> {
         let expr = self.parse_expr()?;
         let alias = if self.parse_keyword(Keyword::AS) {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -504,7 +504,7 @@ struct State<'a> {
     pub col: u64,
 }
 
-impl<'a> State<'a> {
+impl State<'_> {
     /// return the next character and advance the stream
     pub fn next(&mut self) -> Option<char> {
         match self.peekable.next() {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1278,7 +1278,8 @@ impl<'a> Tokenizer<'a> {
 
         chars.next();
 
-        if let Some('$') = chars.peek() {
+        // If the dialect does not support dollar-quoted strings, then `$$` is rather a placeholder.
+        if matches!(chars.peek(), Some('$')) && !self.dialect.supports_dollar_placeholder() {
             chars.next();
 
             let mut is_terminated = false;
@@ -1312,10 +1313,14 @@ impl<'a> Tokenizer<'a> {
             };
         } else {
             value.push_str(&peeking_take_while(chars, |ch| {
-                ch.is_alphanumeric() || ch == '_'
+                ch.is_alphanumeric()
+                    || ch == '_'
+                    // Allow $ as a placeholder character if the dialect supports it
+                    || matches!(ch, '$' if self.dialect.supports_dollar_placeholder())
             }));
 
-            if let Some('$') = chars.peek() {
+            // If the dialect does not support dollar-quoted strings, don't look for the end delimiter.
+            if matches!(chars.peek(), Some('$')) && !self.dialect.supports_dollar_placeholder() {
                 chars.next();
 
                 'searching_for_end: loop {
@@ -1885,7 +1890,7 @@ fn take_char_from_hex_digits(
 mod tests {
     use super::*;
     use crate::dialect::{
-        BigQueryDialect, ClickHouseDialect, HiveDialect, MsSqlDialect, MySqlDialect,
+        BigQueryDialect, ClickHouseDialect, HiveDialect, MsSqlDialect, MySqlDialect, SQLiteDialect,
     };
     use core::fmt::Debug;
 
@@ -2318,6 +2323,30 @@ mod tests {
                     column: 91
                 }
             })
+        );
+    }
+
+    #[test]
+    fn tokenize_dollar_placeholder() {
+        let sql = String::from("SELECT $$, $$ABC$$, $ABC$, $ABC");
+        let dialect = SQLiteDialect {};
+        let tokens = Tokenizer::new(&dialect, &sql).tokenize().unwrap();
+        assert_eq!(
+            tokens,
+            vec![
+                Token::make_keyword("SELECT"),
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("$$".into()),
+                Token::Comma,
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("$$ABC$$".into()),
+                Token::Comma,
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("$ABC$".into()),
+                Token::Comma,
+                Token::Whitespace(Whitespace::Space),
+                Token::Placeholder("$ABC".into()),
+            ]
         );
     }
 

--- a/tests/sqlparser_sqlite.rs
+++ b/tests/sqlparser_sqlite.rs
@@ -568,6 +568,16 @@ fn test_dollar_identifier_as_placeholder() {
         }
         _ => unreachable!(),
     }
+
+    // $$ is a valid placeholder in SQLite
+    match sqlite().verified_expr("id = $$") {
+        Expr::BinaryOp { op, left, right } => {
+            assert_eq!(op, BinaryOperator::Eq);
+            assert_eq!(left, Box::new(Expr::Identifier(Ident::new("id"))));
+            assert_eq!(right, Box::new(Expr::Value(Placeholder("$$".to_string()))));
+        }
+        _ => unreachable!(),
+    }
 }
 
 fn sqlite() -> TestedDialects {


### PR DESCRIPTION
Relevant: apache#1402

```
SQLite version 3.43.2 2023-10-10 13:08:14
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database. sqlite> .mode box
sqlite> .nullvalue NULL
sqlite> SELECT $$, $$ABC$$, $ABC$, $ABC;
┌──────┬─────────┬───────┬──────┐
│  $$  │ $$ABC$$ │ $ABC$ │ $ABC │
├──────┼─────────┼───────┼──────┤
│ NULL │ NULL    │ NULL  │ NULL │
└──────┴─────────┴───────┴──────┘
```